### PR TITLE
Implement TechPulse frontend prototype dashboard

### DIFF
--- a/apps/web/app/page.js
+++ b/apps/web/app/page.js
@@ -1,276 +1,150 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
 
-const FEEDS = [
-  'https://techcrunch.com/feed/',
-  'https://feeds.arstechnica.com/arstechnica/index',
-  'https://www.theverge.com/rss/index.xml',
-  'https://hnrss.org/frontpage',
-  'https://www.reddit.com/r/MachineLearning/.rss',
-  'https://www.reddit.com/r/technology/.rss',
-  'https://www.wired.com/feed/rss',
-  'https://feeds.bloomberg.com/bloomberg/technologynews',
-  'https://www.fastcompany.com/rss',
-  'https://www.engadget.com/rss.xml'
-];
+import React, { useEffect, useMemo, useState } from 'react';
 
-const STOP_WORDS = new Set([
-  'the', 'and', 'for', 'with', 'from', 'that', 'this', 'into', 'your', 'are', 'new', 'how', 'why',
-  'not', 'but', 'you', 'all', 'its', 'has', 'have', 'will', 'can', 'more', 'about', 'after', 'over',
-  'under', 'what', 'when', 'where', 'their', 'they', 'them', 'than', 'out', 'top', 'best', 'was',
-  'were', 'our', 'his', 'her', 'she', 'him', 'who', 'just', 'get', 'big', 'tech', 'news'
-]);
+const clamp = (n, min = 0, max = 100) => Math.max(min, Math.min(max, n));
+const normalize = (n, min = 0, max = 100) => clamp(((n - min) / (max - min)) * 100);
+const daysAgo = (d) => new Date(Date.now() - d * 24 * 60 * 60 * 1000).toISOString();
+const rand = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
 
-const COMPANY_INTELLIGENCE = {
-  nvidia: {
-    industry: 'Semiconductors / AI Infrastructure',
-    ceo: 'Jensen Huang',
-    board: 'Tench Coxe, Mark Stevens, Dawn Hudson and others',
-    vision: 'Accelerate computing for AI, robotics, and simulation.',
-    strategy: 'Own the full-stack AI platform from chips to developer tooling.',
-    hotPickReason: 'AI demand continues to drive data-center momentum and pricing power.'
-  },
-  openai: {
-    industry: 'Artificial Intelligence Platforms',
-    ceo: 'Sam Altman',
-    board: 'Bret Taylor (chair), Larry Summers, Adam D’Angelo and others',
-    vision: 'Build safe and broadly useful AI systems.',
-    strategy: 'Ship high-utility models and ecosystem tools across enterprise and consumer apps.',
-    hotPickReason: 'Rapid enterprise adoption and ecosystem lock-in around AI assistants.'
-  },
-  microsoft: {
-    industry: 'Cloud & Enterprise Software',
-    ceo: 'Satya Nadella',
-    board: 'John W. Thompson, Reid Hoffman, Emma Walmsley and others',
-    vision: 'Empower every person and organization to achieve more.',
-    strategy: 'Embed AI copilots into productivity and cloud workflows.',
-    hotPickReason: 'AI + cloud bundling strengthens platform stickiness and recurring revenue.'
-  },
-  meta: {
-    industry: 'Consumer Internet / Social / AI',
-    ceo: 'Mark Zuckerberg',
-    board: 'Marc Andreessen, Peggy Alford, Nancy Killefer and others',
-    vision: 'Advance social connection and immersive digital experiences.',
-    strategy: 'Invest heavily in open AI models and ad-tech optimization.',
-    hotPickReason: 'AI-driven engagement and ad performance are improving monetization.'
-  },
-  default: {
-    industry: 'Emerging Technology',
-    ceo: 'N/A',
-    board: 'N/A',
-    vision: 'Use innovation to solve high-value market problems.',
-    strategy: 'Scale product-market fit while compounding data advantages.',
-    hotPickReason: 'Signal velocity and source diversity suggest increasing market attention.'
-  }
+const SOURCE_ICON = { News: '📰', YouTube: '▶️', Reddit: '💬', HN: '#️⃣', X: '🔗' };
+const SOURCE_CREDIBILITY = { News: 85, HN: 80, YouTube: 65, Reddit: 55, X: 50 };
+const TOPIC_KEYWORDS = {
+  'AI Agents': ['agent', 'autonomous', 'workflow'],
+  'LLM Infrastructure': ['inference', 'vector', 'orchestration', 'llm'],
+  Semiconductors: ['chip', 'semiconductor', 'fab', 'nm'],
+  Robotics: ['robot', 'humanoid', 'automation'],
+  'Battery Tech': ['battery', 'solid-state', 'lithium']
 };
 
-async function fetchFeed(url) {
-  const proxy = 'https://api.allorigins.win/raw?url=';
-  const response = await fetch(proxy + encodeURIComponent(url));
-  const text = await response.text();
-  const parser = new DOMParser();
-  const xml = parser.parseFromString(text, 'text/xml');
-  const entries = Array.from(xml.querySelectorAll('item, entry'));
-  return entries.map((entry) => {
-    const titleNode = entry.querySelector('title');
-    const linkNode = entry.querySelector('link');
-    const pubNode = entry.querySelector('pubDate') || entry.querySelector('updated') || entry.querySelector('published');
-    const sourceNode = entry.querySelector('source') || entry.querySelector('author');
-    const linkHref = linkNode?.getAttribute('href');
+function extractTopics(text) {
+  const t = text.toLowerCase();
+  return Object.entries(TOPIC_KEYWORDS).filter(([, keys]) => keys.some((k) => t.includes(k))).map(([name]) => name);
+}
+function extractSignals(text) {
+  const t = text.toLowerCase();
+  return { fundingHint: /raised|series|funding/.test(t), supplyChainHint: /supplier|manufactur|fab|partnered/.test(t) };
+}
+
+const COMPANIES = ['OpenAI', 'NVIDIA', 'AMD', 'Tesla', 'Anthropic', 'Google', 'Amazon', 'Microsoft', 'TSMC'];
+const TREND_DEFS = [
+  { id: 't1', name: 'AI Agents', desc: 'Autonomous systems coordinating tasks.' },
+  { id: 't2', name: 'LLM Infrastructure', desc: 'Scaling inference and orchestration.' },
+  { id: 't3', name: 'Semiconductors', desc: 'Advanced nodes and supply chains.' },
+  { id: 't4', name: 'Robotics', desc: 'Humanoid and industrial automation.' },
+  { id: 't5', name: 'Battery Tech', desc: 'Next-gen energy storage.' },
+  { id: 't6', name: 'Privacy & Security', desc: 'Data protection and zero trust.' }
+];
+
+function makeFeed() {
+  const sources = ['News', 'YouTube', 'Reddit', 'HN', 'X'];
+  return Array.from({ length: 48 }).map((_, i) => {
+    const trend = pick(TREND_DEFS);
+    const source = pick(sources);
+    const title = `${trend.name} update: ${pick(['new funding round', 'performance surge', 'partnered with supplier', 'launches v2'])}`;
+    const summary = `${pick(COMPANIES)} reports ${pick(['raised capital', 'supply chain expansion', 'rapid adoption', 'new architecture'])} impacting ${trend.name}.`;
+    const sig = extractSignals(`${title} ${summary}`);
+    const topics = extractTopics(`${title} ${summary}`);
     return {
-      title: titleNode?.textContent?.trim() || '',
-      link: linkHref || linkNode?.textContent?.trim() || '',
-      pubDate: pubNode ? new Date(pubNode.textContent.trim()) : null,
-      source: sourceNode?.textContent?.trim() || new URL(url).hostname.replace('www.', '')
+      id: `f${i}`,
+      title,
+      summary,
+      source: { type: source },
+      publishedAt: daysAgo(rand(0, 30)),
+      entities: [pick(COMPANIES)],
+      topics: topics.length ? topics : [trend.name],
+      signals: {
+        velocity: rand(30, 95), mentions: rand(5, 120), novelty: rand(30, 95), credibility: SOURCE_CREDIBILITY[source],
+        supplyChainHint: Boolean(sig.supplyChainHint), fundingHint: Boolean(sig.fundingHint)
+      },
+      trendId: trend.id
     };
   });
 }
 
-function extractKeywords(items) {
-  const frequency = new Map();
-  items.forEach((item) => {
-    const normalized = item.title
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, ' ')
-      .split(/\s+/)
-      .filter((token) => token.length > 2 && !STOP_WORDS.has(token));
-
-    normalized.forEach((token) => {
-      frequency.set(token, (frequency.get(token) || 0) + 1);
-    });
+function computeTrends(feed) {
+  return TREND_DEFS.map((t) => {
+    const items = feed.filter((f) => f.trendId === t.id);
+    const velocity = items.reduce((a, b) => a + b.signals.velocity, 0) / Math.max(1, items.length);
+    const mentions = items.reduce((a, b) => a + b.signals.mentions, 0);
+    const novelty = items.reduce((a, b) => a + b.signals.novelty, 0) / Math.max(1, items.length);
+    const credibility = items.reduce((a, b) => a + b.signals.credibility, 0) / Math.max(1, items.length);
+    const diversity = new Set(items.map((i) => i.source.type)).size * 20;
+    const momentum = normalize(velocity + mentions / 5);
+    const score = clamp(0.35 * momentum + 0.35 * normalize(novelty) + 0.2 * normalize(credibility) + 0.1 * normalize(diversity));
+    return {
+      id: t.id,
+      name: t.name,
+      description: t.desc,
+      score,
+      breakdown: { momentum, novelty: normalize(novelty), credibility: normalize(credibility), diversity: normalize(diversity) },
+      timeseries: Array.from({ length: 14 }).map((__, i) => ({ date: `D-${13 - i}`, score: clamp(score + rand(-10, 10)) })),
+      topSignals: [items.some((i) => i.signals.fundingHint) && 'Funding Hint', items.some((i) => i.signals.supplyChainHint) && 'Supply Chain Signal'].filter(Boolean)
+    };
   });
-
-  return Array.from(frequency.entries())
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 26)
-    .map(([term, count]) => ({ term, count }));
 }
 
-function estimateMomentum(items, keyword) {
-  const matchCount = items.filter((item) => item.title.toLowerCase().includes(keyword)).length;
-  return Math.min(100, 35 + matchCount * 11);
-}
-
-function companyFromText(text) {
-  const lower = text.toLowerCase();
-  const known = Object.keys(COMPANY_INTELLIGENCE).find((name) => name !== 'default' && lower.includes(name));
-  return known || 'default';
-}
+const card = { border: '1px solid #e5e7eb', borderRadius: 12, background: 'var(--card)', color: 'var(--text)' };
+const btn = { border: '1px solid #cbd5e1', background: 'white', borderRadius: 8, padding: '8px 10px', cursor: 'pointer' };
 
 export default function Page() {
-  const [items, setItems] = useState([]);
-  const [selectedKeyword, setSelectedKeyword] = useState('');
-  const [search, setSearch] = useState('');
-  const [selectedArticle, setSelectedArticle] = useState(null);
+  const [dark, setDark] = useState(false);
+  const [feed, setFeed] = useState(() => makeFeed());
+  const [tab, setTab] = useState('dashboard');
+  const trends = useMemo(() => computeTrends(feed), [feed]);
+  const [activeTrend, setActiveTrend] = useState('t1');
+  const active = trends.find((t) => t.id === activeTrend) || trends[0];
+  const sourceMix = useMemo(() => {
+    const map = {}; feed.forEach((f) => (map[f.source.type] = (map[f.source.type] || 0) + 1)); return map;
+  }, [feed]);
 
   useEffect(() => {
-    async function load() {
-      const all = [];
-      for (const feed of FEEDS) {
-        try {
-          const feedItems = await fetchFeed(feed);
-          all.push(...feedItems);
-        } catch (err) {
-          console.error('Failed to fetch feed:', feed, err);
-        }
-      }
+    document.body.style.margin = '0';
+    document.documentElement.style.setProperty('--bg', dark ? '#0b1020' : '#f8fafc');
+    document.documentElement.style.setProperty('--card', dark ? '#141b2e' : '#ffffff');
+    document.documentElement.style.setProperty('--text', dark ? '#f8fafc' : '#0f172a');
+    document.documentElement.style.setProperty('--muted', dark ? '#9ca3af' : '#64748b');
+  }, [dark]);
 
-      all.sort((a, b) => {
-        const aTime = a.pubDate ? a.pubDate.getTime() : 0;
-        const bTime = b.pubDate ? b.pubDate.getTime() : 0;
-        return bTime - aTime;
-      });
-      setItems(all.slice(0, 120));
-    }
-    load();
-  }, []);
-
-  const keywords = useMemo(() => extractKeywords(items), [items]);
-
-  const filteredItems = useMemo(() => {
-    return items.filter((item) => {
-      const byKeyword = selectedKeyword ? item.title.toLowerCase().includes(selectedKeyword) : true;
-      const bySearch = search ? item.title.toLowerCase().includes(search.toLowerCase()) : true;
-      return byKeyword && bySearch;
-    });
-  }, [items, search, selectedKeyword]);
-
-  const researchCard = useMemo(() => {
-    if (!selectedArticle) {
-      return null;
-    }
-    const companyKey = companyFromText(selectedArticle.title);
-    const profile = COMPANY_INTELLIGENCE[companyKey] || COMPANY_INTELLIGENCE.default;
-    return {
-      company: companyKey === 'default' ? 'Emerging Company (inferred)' : companyKey[0].toUpperCase() + companyKey.slice(1),
-      momentumScore: estimateMomentum(items, selectedKeyword || companyKey),
-      ...profile
-    };
-  }, [selectedArticle, items, selectedKeyword]);
-
-  return (
-    <main style={{ maxWidth: 1150, margin: '30px auto', padding: '0 16px', fontFamily: 'Inter, Arial, sans-serif' }}>
-      <h1 style={{ marginBottom: 8 }}>TechPulse Discovery Sandbox</h1>
-      <p style={{ marginTop: 0, color: '#4b5563' }}>
-        Explore momentum signals: pick keywords from the cloud, search headlines, then open an article to generate company research context.
-      </p>
-
-      <section style={{ background: '#f8fafc', borderRadius: 14, padding: 18, border: '1px solid #e2e8f0', marginBottom: 20 }}>
-        <h2 style={{ marginTop: 0, fontSize: '1.1rem' }}>Interactive keyword cloud</h2>
-        {keywords.length === 0 ? (
-          <p>Loading trend vocabulary...</p>
-        ) : (
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
-            {keywords.map((keyword) => {
-              const size = 12 + keyword.count * 2;
-              const active = selectedKeyword === keyword.term;
-              return (
-                <button
-                  key={keyword.term}
-                  onClick={() => setSelectedKeyword(active ? '' : keyword.term)}
-                  style={{
-                    fontSize: `${size}px`,
-                    borderRadius: 999,
-                    border: active ? '1px solid #1d4ed8' : '1px solid #cbd5e1',
-                    padding: '6px 12px',
-                    background: active ? '#dbeafe' : 'white',
-                    color: '#1f2937',
-                    cursor: 'pointer'
-                  }}
-                >
-                  {keyword.term} ({keyword.count})
-                </button>
-              );
-            })}
-          </div>
-        )}
-      </section>
-
-      <section style={{ display: 'grid', gridTemplateColumns: '1.3fr 1fr', gap: 16 }}>
-        <div style={{ border: '1px solid #e5e7eb', borderRadius: 14, padding: 16 }}>
-          <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 12 }}>
-            <input
-              placeholder='Search keywords (e.g., ai chips, robotics, startup)'
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              style={{ flex: 1, border: '1px solid #cbd5e1', borderRadius: 10, padding: '10px 12px' }}
-            />
-            {selectedKeyword && (
-              <button onClick={() => setSelectedKeyword('')} style={{ padding: '10px 12px', borderRadius: 10, border: '1px solid #cbd5e1', background: 'white' }}>
-                Clear “{selectedKeyword}”
-              </button>
-            )}
-          </div>
-
-          <h3 style={{ marginTop: 0 }}>Signal feed ({filteredItems.length})</h3>
-          <div style={{ maxHeight: 520, overflow: 'auto' }}>
-            {filteredItems.slice(0, 45).map((item, idx) => (
-              <article
-                key={`${item.link}-${idx}`}
-                onClick={() => setSelectedArticle(item)}
-                style={{
-                  padding: '10px 8px',
-                  borderRadius: 10,
-                  marginBottom: 6,
-                  border: selectedArticle?.link === item.link ? '1px solid #2563eb' : '1px solid transparent',
-                  background: selectedArticle?.link === item.link ? '#eff6ff' : 'transparent',
-                  cursor: 'pointer'
-                }}
-              >
-                <a href={item.link} target='_blank' rel='noopener noreferrer' style={{ color: '#0f172a', fontWeight: 600, textDecoration: 'none' }}>
-                  {item.title}
-                </a>
-                <div style={{ fontSize: '0.8rem', color: '#64748b', marginTop: 3 }}>
-                  {item.source} • {item.pubDate ? item.pubDate.toLocaleString() : 'Unknown date'}
-                </div>
-              </article>
-            ))}
-          </div>
+  return <main style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--text)', fontFamily: 'Inter, Arial, sans-serif' }}>
+    <div style={{ position: 'sticky', top: 0, borderBottom: '1px solid #33415533', background: '#ffffff66', backdropFilter: 'blur(6px)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 20px' }}>
+        <strong style={{ fontSize: 24 }}>TechPulse</strong>
+        <div style={{ flex: 1, textAlign: 'center' }}><input placeholder='Search trends, topics, companies' style={{ width: '50%', padding: '8px 10px', borderRadius: 8, border: '1px solid #cbd5e1' }} /></div>
+        <button onClick={() => setFeed(makeFeed())} style={btn}>⟳ Refresh</button>
+        <button onClick={() => setDark((d) => !d)} style={btn}>{dark ? '☀️' : '🌙'}</button>
+      </div>
+    </div>
+    <div style={{ padding: 24 }}>
+      <div style={{ display: 'flex', gap: 10, marginBottom: 20 }}>{['dashboard', 'trends', 'feed', 'sources', 'settings'].map((t) => <button key={t} onClick={() => setTab(t)} style={{ ...btn, background: tab === t ? '#2563eb' : 'transparent', color: tab === t ? '#fff' : 'var(--text)' }}>{t}</button>)}</div>
+      {tab === 'dashboard' && <>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 12, marginBottom: 16 }}>
+          <KPI title='Active Trends' value={trends.length} icon='🧱' />
+          <KPI title='Highest Momentum' value={Math.round(Math.max(...trends.map((t) => t.breakdown.momentum)))} icon='📈' />
+          <KPI title='Highest Novelty' value={Math.round(Math.max(...trends.map((t) => t.breakdown.novelty)))} icon='✨' />
+          <KPI title='Top Credibility' value={Math.round(Math.max(...trends.map((t) => t.breakdown.credibility)))} icon='🛡️' />
         </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 16 }}>
+          <div style={{ ...card, padding: 14 }}>
+            <h3>Trend Momentum</h3>
+            <select value={activeTrend} onChange={(e) => setActiveTrend(e.target.value)}>{trends.map((t) => <option key={t.id} value={t.id}>{t.name}</option>)}</select>
+            <MiniLine data={active.timeseries} />
+          </div>
+          <div style={{ ...card, padding: 14 }}><h3>Source Mix</h3>{Object.entries(sourceMix).map(([k, v]) => <div key={k}>{k}: {v}</div>)}</div>
+        </div>
+      </>}
+      {tab === 'trends' && <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 12 }}>{trends.map((t) => <TrendCard key={t.id} trend={t} />)}</div>}
+      {tab === 'feed' && <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 12 }}>{feed.map((f) => <div key={f.id} style={{ ...card, padding: 12 }}><div>{SOURCE_ICON[f.source.type]} {f.source.type}</div><strong>{f.title}</strong><p>{f.summary}</p></div>)}</div>}
+      {tab === 'sources' && ['News', 'YouTube', 'Reddit', 'HN', 'X'].map((s) => <div key={s} style={{ ...card, padding: 12, marginBottom: 8, display: 'flex', justifyContent: 'space-between' }}><span>{s}</span><span>Connected</span></div>)}
+      {tab === 'settings' && <div style={{ ...card, padding: 14 }}><h3>Extraction Settings</h3><input type='range' defaultValue={50} /><input type='range' defaultValue={50} /><input type='range' defaultValue={50} /></div>}
+    </div>
+  </main>;
+}
 
-        <aside style={{ border: '1px solid #e5e7eb', borderRadius: 14, padding: 16, background: '#fcfcfd' }}>
-          <h3 style={{ marginTop: 0 }}>Research presentation</h3>
-          {!selectedArticle ? (
-            <p style={{ color: '#6b7280' }}>Select a keyword + article to generate company/industry context.</p>
-          ) : (
-            <>
-              <p style={{ marginTop: 0 }}><strong>Selected article:</strong> {selectedArticle.title}</p>
-              <p style={{ marginBottom: 6 }}><strong>Company:</strong> {researchCard.company}</p>
-              <p style={{ margin: '6px 0' }}><strong>Industry:</strong> {researchCard.industry}</p>
-              <p style={{ margin: '6px 0' }}><strong>CEO:</strong> {researchCard.ceo}</p>
-              <p style={{ margin: '6px 0' }}><strong>Board:</strong> {researchCard.board}</p>
-              <p style={{ margin: '6px 0' }}><strong>Vision:</strong> {researchCard.vision}</p>
-              <p style={{ margin: '6px 0' }}><strong>Strategy:</strong> {researchCard.strategy}</p>
-              <p style={{ margin: '6px 0 14px' }}><strong>Why hot:</strong> {researchCard.hotPickReason}</p>
-
-              <div style={{ background: '#eef2ff', borderRadius: 10, padding: '10px 12px' }}>
-                <div style={{ fontWeight: 600, marginBottom: 4 }}>Momentum score</div>
-                <div style={{ fontSize: '1.25rem' }}>{researchCard.momentumScore}/100</div>
-              </div>
-            </>
-          )}
-        </aside>
-      </section>
-    </main>
-  );
+function KPI({ title, value, icon }) { return <div style={{ ...card, padding: 12 }}><div>{icon} {title}</div><strong style={{ fontSize: 28 }}>{value}</strong></div>; }
+function TrendCard({ trend }) { return <div style={{ ...card, padding: 12 }}><div style={{ display: 'flex', justifyContent: 'space-between' }}><strong>{trend.name}</strong><span>{Math.round(trend.score)}</span></div><p style={{ color: 'var(--muted)' }}>{trend.description}</p><small>{trend.topSignals.join(' · ') || 'No highlighted signals'}</small></div>; }
+function MiniLine({ data }) {
+  const points = data.map((d, i) => `${(i / (data.length - 1)) * 100},${100 - d.score}`).join(' ');
+  return <svg viewBox='0 0 100 100' style={{ width: '100%', height: 220, background: '#f1f5f9', borderRadius: 8 }}><polyline fill='none' stroke='#2563eb' strokeWidth='2' points={points} /></svg>;
 }


### PR DESCRIPTION
### Motivation
- Provide a self-contained interactive TechPulse frontend prototype for exploring synthetic trend signals and lightweight visualizations inside the repository's Next.js app.  
- Replace the prior homepage with a dependency-light single-file UI to make iteration and previewing easier without relying on unavailable packages.

### Description
- Replaced `apps/web/app/page.js` with a single-file React prototype that implements synthetic feed generation (`makeFeed`), topic extraction (`extractTopics`), signal heuristics (`extractSignals`), and trend aggregation/scoring (`computeTrends`).
- Added a tabbed UI (dashboard, trends, feed, sources, settings) with sticky top nav, search input, refresh button, dark-mode toggle, KPI cards, source-mix summary, trend cards, and an inline SVG mini line chart (`MiniLine`).
- Removed external feed parsing and heavyweight UI dependencies in favor of an in-file demo (emoji source icons, inline SVG for charts) to keep the page runnable without extra packages.
- Introduced small helper utilities (`clamp`, `normalize`, `rand`, `pick`, `daysAgo`) and local styles/constants used by the prototype.

### Testing
- Ran `npx next build`, which completed successfully and validated the app bundle for production output.  
- Ran `npm run build`, which failed due to the project `build` script calling the removed `next export` command in Next.js 14 (known issue surfaced during validation).  
- Attempted `npm install` to add `lucide-react`/`recharts`, but the install failed with a registry `403` so the prototype was adapted to avoid those packages.  
- Started the dev server with `npm run dev` and captured a screenshot of the running UI via a Playwright script to validate the rendered frontend.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8d95544c8328acdb2dc8a1aacfd7)