### PR TITLE
Clean up local development baseline

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -9,18 +9,13 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: web-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +23,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: npm
+          cache-dependency-path: apps/web/package.json
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-worker-workflow.yml
+++ b/.github/workflows/deploy-worker-workflow.yml
@@ -1,4 +1,5 @@
-name: Deploy Worker
+name: Worker Check and Deploy
+
 on:
   push:
     paths: ["apps/worker/**", ".github/workflows/deploy-worker-workflow.yml"]
@@ -9,17 +10,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
-      - name: Install deps
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: apps/worker/package.json
+
+      - name: Install dependencies
         run: |
           cd apps/worker
-          bun install
-      - name: Publish
+          npm install
+
+      - name: Typecheck Worker
+        run: |
+          cd apps/worker
+          npm run typecheck
+
+      - name: Deploy Worker
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: |
-            --version
-            publish
+          workingDirectory: apps/worker
+          command: deploy --config wrangler.toml
         env:
           CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ TechPulse is a trend intelligence platform that aggregates signals from multiple
 
 ## Structure
 
-- **`apps/web`** – canonical frontend built with Next.js (App Router). The homepage is located at `apps/web/app/page.js` and fetches live aggregated data from the Worker backend.
-- **`apps/worker`** – canonical backend implemented as a Cloudflare Worker. It aggregates RSS/Atom feeds defined in the `FEEDS` environment variable and exposes them via `/aggregate`.
+- **`apps/web`** - canonical frontend built with Next.js (App Router). The homepage is located at `apps/web/app/page.js` and fetches live aggregated data from the Worker backend.
+- **`apps/worker`** - canonical backend implemented as a Cloudflare Worker. It aggregates RSS/Atom feeds defined in the `FEEDS` environment variable and exposes them via `/aggregate`.
 
-Legacy static pages and duplicate front‑end implementations have been removed to avoid confusion. The **only** frontend entry point is `apps/web/app/page.js`.
+Legacy static pages and duplicate frontend implementations have been removed to avoid confusion. The **only** frontend entry point is `apps/web/app/page.js`.
 
 ## Local Development
 
@@ -15,9 +15,11 @@ Legacy static pages and duplicate front‑end implementations have been removed 
 
 ```bash
 cd apps/worker
-bun install
-bunx wrangler dev
+npm install
+npm run dev
 ```
+
+The Worker runs at http://127.0.0.1:8787 by default. Its aggregate endpoint is http://127.0.0.1:8787/aggregate.
 
 ### Web
 
@@ -37,6 +39,23 @@ npm run dev
 
 Open http://localhost:3000/ to view the dashboard.
 
+## Checks
+
+```bash
+cd apps/web
+npm run build
+
+cd ../worker
+npm run typecheck
+```
+
 ## Deployment
 
-Deploy the Worker using Cloudflare Wrangler. For the frontend, build with `next build` (no static export) and deploy the output to a platform that supports serverless functions or dynamic environments. GitHub Pages is not suited for dynamic fetches; instead use Vercel or another serverless host.
+Deploy the Worker with Cloudflare Wrangler:
+
+```bash
+cd apps/worker
+npm run deploy
+```
+
+For the frontend, build with `next build` and deploy to a host that supports dynamic Next.js rendering and environment variables. GitHub Pages is not suited for this app because the dashboard fetches live Worker data at request time.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,16 +1,6 @@
 /** @type {import('next').NextConfig} */
-const isGitHubPages = process.env.GITHUB_ACTIONS === 'true';
-
 const nextConfig = {
-  output: 'export',
-  images: { unoptimized: true },
-  trailingSlash: true,
-  ...(isGitHubPages
-    ? {
-        basePath: '/Tech_Pulse',
-        assetPrefix: '/Tech_Pulse/'
-      }
-    : {})
+  reactStrictMode: true
 };
 
 module.exports = nextConfig;

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "techpulse-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev --config wrangler.toml",
+    "deploy": "wrangler deploy --config wrangler.toml",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240524.0",
+    "typescript": "^5.4.5",
+    "wrangler": "^3.57.2"
+  }
+}

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Remove the stale GitHub Pages static export settings from the dynamic Next.js app config.
- Add a self-contained Worker package with local dev, deploy, and typecheck scripts.
- Add Worker TypeScript configuration and update the Worker workflow to install, typecheck, and deploy from `apps/worker`.
- Simplify the web workflow into an honest build check and refresh README local setup instructions.

## Testing

- Parsed the new Worker `package.json` and `tsconfig.json` successfully with Node.
- Could not run `npm install`, `npm run build`, or `npm run typecheck` in this Codex shell because `npm` is not available on PATH in the local runtime.